### PR TITLE
fix: capitalization on quest titles

### DIFF
--- a/AdditionalQuestsCode/AdditionalQuestsCode/Quests/HeadmanNeedsMilitiaWeaponsIssueBehavior.cs
+++ b/AdditionalQuestsCode/AdditionalQuestsCode/Quests/HeadmanNeedsMilitiaWeaponsIssueBehavior.cs
@@ -48,7 +48,7 @@ namespace AdditionalQuestsCode.Quests
             {
                 get
                 {
-                    TextObject textObject = new TextObject("{ISSUE_SETTLEMENT} needs spears for militia", null);
+                    TextObject textObject = new TextObject("{ISSUE_SETTLEMENT} Needs Spears for Militia", null);
                     textObject.SetTextVariable("ISSUE_SETTLEMENT", base.IssueSettlement.Name);
                     return textObject;
                 }

--- a/AdditionalQuestsCode/AdditionalQuestsCode/Quests/NobleWantsTrainingBattleIssueBehavior.cs
+++ b/AdditionalQuestsCode/AdditionalQuestsCode/Quests/NobleWantsTrainingBattleIssueBehavior.cs
@@ -61,7 +61,7 @@ namespace AdditionalQuestsCode.Quests
             {
                 get
                 {
-                    TextObject textObject = new TextObject("{NOBLE_NAME} wants a training battle", null);
+                    TextObject textObject = new TextObject("{NOBLE_NAME} Wants a Training Battle", null);
                     textObject.SetTextVariable("NOBLE_NAME", base.IssueOwner.Name);
                     return textObject;
                 }

--- a/AdditionalQuestsCode/AdditionalQuestsCode/Quests/StarvingTownNeedsFoodIssueBehavior.cs
+++ b/AdditionalQuestsCode/AdditionalQuestsCode/Quests/StarvingTownNeedsFoodIssueBehavior.cs
@@ -46,7 +46,7 @@ namespace AdditionalQuestsCode.Quests
             {
                 get
                 {
-                    TextObject textObject = new TextObject("Food crisis in {ISSUE_SETTLEMENT}", null);
+                    TextObject textObject = new TextObject("Food Crisis in {ISSUE_SETTLEMENT}", null);
                     textObject.SetTextVariable("ISSUE_SETTLEMENT", base.IssueSettlement.Name);
                     return textObject;
                 }

--- a/AdditionalQuestsCode/AdditionalQuestsCode/Quests/VillageBanditArmyRaidIssueBehavior.cs
+++ b/AdditionalQuestsCode/AdditionalQuestsCode/Quests/VillageBanditArmyRaidIssueBehavior.cs
@@ -61,7 +61,7 @@ namespace AdditionalQuestsCode.Quests
             {
                 get
                 {
-                    TextObject textObject = new TextObject("Bandit army heading to {ISSUE_SETTLEMENT}!", null);
+                    TextObject textObject = new TextObject("Bandit Army Heading to {ISSUE_SETTLEMENT}!", null);
                     textObject.SetTextVariable("ISSUE_SETTLEMENT", base.IssueSettlement.Name);
                     return textObject;
                 }


### PR DESCRIPTION
The vanilla quests have capitalization so when I see these quests pop up without them. I instantly know it's a quest from the mod which can take away from the vanilla experience.

This PR adds capitalization to the quest titles for consistency with the vanilla game.